### PR TITLE
fix: `PortableExperience` module name mismatch

### DIFF
--- a/src/worker-sdk6/client/index.ts
+++ b/src/worker-sdk6/client/index.ts
@@ -25,7 +25,7 @@ export const LoadableApis = {
   EthereumController: EthereumControllerServiceClient.create,
   ParcelIdentity: ParcelIdentityServiceClient.create,
   Players: PlayersServiceClient.create,
-  PortableExperience: PortableExperienceServiceClient.create,
+  PortableExperiences: PortableExperienceServiceClient.create,
   RestrictedActions: RestrictedActionsServiceClient.create,
   UserActionModule: UserActionModuleServiceClient.create,
   UserIdentity: UserIdentityServiceClient.create,
@@ -37,7 +37,7 @@ export const LoadableApis = {
   LegacyEthereumController: EthereumControllerServiceClient.createLegacy,
   LegacyParcelIdentity: ParcelIdentityServiceClient.createLegacy,
   LegacyPlayers: PlayersServiceClient.createLegacy,
-  LegacyPortableExperience: PortableExperienceServiceClient.createLegacy,
+  LegacyPortableExperiences: PortableExperienceServiceClient.createLegacy,
 
   // TODO: validate which of the following is actually used.
   LegacyRestrictedActions: RestrictedActionsServiceClient.createLegacy,


### PR DESCRIPTION
related to issue: https://github.com/decentraland/sdk/issues/570
the name for the module for PX mismatch the import from scenes.

scenes are importing `from '@decentraland/PortableExperiences'`
but `LoadableApis` properties name were `PortableExperience` and `LegacyPortableExperience` (ending without 's')
so it wasn't being found while trying to load them
https://github.com/decentraland/scene-runtime/blob/898f0a79bab1f139f676c301b48231d7f3768539/src/worker-sdk6/runtime/DecentralandInterface.ts#L290-L297