### PR TITLE
fix: line offset while debugging on vscode/chrome with sourcemaps

### DIFF
--- a/src/worker-sdk6/index.ts
+++ b/src/worker-sdk6/index.ts
@@ -202,7 +202,7 @@ export async function startSceneRuntime(client: RpcClient) {
     const sourceCode = await codeRequest.text()
 
     // run the code of the scene
-    await customEval(sourceCode, runtimeExecutionContext)
+    await customEval(sourceCode, runtimeExecutionContext, isPreview.isPreview)
   } catch (err) {
     await EngineApi.sendBatch({ actions: [initMessagesFinished()] })
 

--- a/src/worker-sdk6/runtime/sandbox.ts
+++ b/src/worker-sdk6/runtime/sandbox.ts
@@ -40,7 +40,7 @@ const allowListES5: Array<keyof typeof globalThis> = [
 // eslint-disable-next-line @typescript-eslint/ban-types
 const defer: (fn: Function) => void = (Promise.resolve().then as any).bind(Promise.resolve() as any)
 
-export async function customEval(code: string, context: any) {
+export async function customEval(code: string, context: any, previewMode: boolean) {
   const sandbox: any = {}
 
   const resultKey = 'SAFE_EVAL_' + Math.floor(Math.random() * 1000000)
@@ -53,7 +53,7 @@ export async function customEval(code: string, context: any) {
   sandbox.window = sandbox
   sandbox.self = sandbox
 
-  return defer(() => new Function('code', `with (this) { ${code} }`).call(sandbox, code))
+  return defer(() => new Function('code', previewMode ? `with (this) { ${code} }` : `with (this) { eval(${JSON.stringify(code)}) }`).call(sandbox, code))
 }
 
 function getES5Context(base: Record<string, any>) {

--- a/src/worker-sdk7/index.ts
+++ b/src/worker-sdk7/index.ts
@@ -94,7 +94,7 @@ export async function startSceneRuntime(client: RpcClient) {
     const sceneModule = createModuleRuntime(runtimeExecutionContext, clientPort, devToolsAdapter)
 
     // run the code of the scene
-    await customEvalSdk7(sourceCode, runtimeExecutionContext)
+    await customEvalSdk7(sourceCode, runtimeExecutionContext, isPreview.isPreview)
 
     if (!sceneModule.exports.onUpdate && !sceneModule.exports.onStart) {
       // there may be cases where onStart is present and onUpdate not for "static-ish" scenes

--- a/src/worker-sdk7/sandbox.ts
+++ b/src/worker-sdk7/sandbox.ts
@@ -62,8 +62,8 @@ export const allowListES2020: Array<keyof typeof globalThis> = [
 // eslint-disable-next-line @typescript-eslint/ban-types
 const defer: (fn: Function) => void = (Promise.resolve().then as any).bind(Promise.resolve() as any)
 
-export async function customEvalSdk7(code: string, context: Record<string | symbol, unknown>) {
-  const func = new Function('globalThis', `with (globalThis) {${code}}`)
+export async function customEvalSdk7(code: string, context: Record<string | symbol, unknown>, previewMode: boolean) {
+  const func = new Function('globalThis', previewMode ? `with (globalThis) {eval(${JSON.stringify(code)})}`: `with (globalThis) {${code}}`)
   const proxy: any = new Proxy(context, {
     has() {
       return true

--- a/test/sandbox.spec.ts
+++ b/test/sandbox.spec.ts
@@ -30,7 +30,7 @@ describe('Sandbox', () => {
       throw new Error('1')
     })
 
-    await expect(() => customEvalSdk7(example, { console: { log } })).rejects.toThrow('1')
+    await expect(() => customEvalSdk7(example, { console: { log } }, false)).rejects.toThrow('1')
     expect(log).toBeCalled()
   })
 
@@ -38,7 +38,7 @@ describe('Sandbox', () => {
     let stack = 'null'
 
     try {
-      await customEvalSdk7(exampleFailingWithStack, {})
+      await customEvalSdk7(exampleFailingWithStack, {}, false)
     } catch (err: any) {
       stack = err.stack
     }
@@ -85,7 +85,7 @@ describe('Sandbox', () => {
       context.log = log
       const sceneModule = createModuleRuntime(context, null as any, devToolsAdapter)
 
-      await customEvalSdk7(src, context)
+      await customEvalSdk7(src, context, false)
 
       await sceneModule.exports.onUpdate!(0.0)
       expect(log).toBeCalledWith(1) // evaluate new result
@@ -97,7 +97,7 @@ describe('Sandbox', () => {
   it('this should be the proxy', async () => {
     const log = jest.fn().mockImplementation((x) => { })
 
-    await customEvalSdk7(example, { console: { log } })
+    await customEvalSdk7(example, { console: { log } }, false)
 
     expect(log).toBeCalledTimes(1)
   })
@@ -105,7 +105,7 @@ describe('Sandbox', () => {
   it('this should be the proxy (eval)', async () => {
     const log = jest.fn().mockImplementation((x) => { })
 
-    await customEvalSdk7(example, { console: { log } })
+    await customEvalSdk7(example, { console: { log } }, false)
 
     expect(log).toBeCalledTimes(1)
   })
@@ -116,7 +116,7 @@ describe('Sandbox', () => {
       that = $
     })
 
-    await customEvalSdk7(`console.log(globalThis)`, { console: { log } })
+    await customEvalSdk7(`console.log(globalThis)`, { console: { log } }, false)
 
     expect(log).toBeCalledTimes(1)
     expect(that.console).toHaveProperty('log')
@@ -139,9 +139,9 @@ describe('Sandbox', () => {
           }
         }
       })
-      await customEvalSdk7('console.log()', context)
+      await customEvalSdk7('console.log()', context, false)
       expect(i).toEqual(1)
-      await customEvalSdk7('console.log()', context)
+      await customEvalSdk7('console.log()', context, false)
       expect(i).toEqual(2)
     })
 
@@ -158,9 +158,9 @@ describe('Sandbox', () => {
           }
         }
       })
-      await customEvalSdk7('console.log()', context)
+      await customEvalSdk7('console.log()', context, false)
       expect(i).toEqual(1)
-      await customEvalSdk7('console.log()', context)
+      await customEvalSdk7('console.log()', context, false)
       expect(i).toEqual(2)
     })
   })
@@ -187,7 +187,7 @@ export function checkExistence(property: string, exists: boolean) {
       that = $
     })
 
-    await customEvalSdk7(`x(globalThis.${property})`, { x })
+    await customEvalSdk7(`x(globalThis.${property})`, { x }, false)
 
     expect(x).toBeCalledTimes(1)
 
@@ -204,7 +204,7 @@ export function checkExistence(property: string, exists: boolean) {
       that = $
     })
 
-    await customEvalSdk7(`x(globalThis.${property})`, { x })
+    await customEvalSdk7(`x(globalThis.${property})`, { x }, false)
 
     expect(x).toBeCalledTimes(1)
 
@@ -221,7 +221,7 @@ export function checkExistence(property: string, exists: boolean) {
       that = $
     })
 
-    await customEvalSdk7(`x(this.${property})`, { x })
+    await customEvalSdk7(`x(this.${property})`, { x }, false)
 
     expect(x).toBeCalledTimes(1)
 
@@ -238,7 +238,7 @@ export function checkExistence(property: string, exists: boolean) {
       that = $
     })
 
-    await customEvalSdk7(`x(this.${property})`, { x })
+    await customEvalSdk7(`x(this.${property})`, { x }, false)
 
     expect(x).toBeCalledTimes(1)
 
@@ -255,7 +255,7 @@ export function checkExistence(property: string, exists: boolean) {
       that = $
     })
 
-    await customEvalSdk7(`x(${property})`, { x })
+    await customEvalSdk7(`x(${property})`, { x }, false)
 
     expect(x).toBeCalledTimes(1)
     if (exists) {
@@ -271,7 +271,7 @@ export function checkExistence(property: string, exists: boolean) {
       that = $
     })
 
-    await customEvalSdk7(`x(${property})`, { x })
+    await customEvalSdk7(`x(${property})`, { x }, false)
 
     expect(x).toBeCalledTimes(1)
     if (exists) expect(that).not.toStrictEqual(undefined)
@@ -287,7 +287,7 @@ describe('dcl runtime', () => {
     const sceneModule = createModuleRuntime(context, null as any, devToolsAdapter)
 
     // run the code of the scene
-    await customEvalSdk7('exports.onUpdate = function() { return 123 }', context)
+    await customEvalSdk7('exports.onUpdate = function() { return 123 }', context, false)
 
     expect(await sceneModule.exports.onUpdate!(0)).toEqual(123)
   })
@@ -299,7 +299,7 @@ describe('dcl runtime', () => {
     const sceneModule = createModuleRuntime(context, null as any, devToolsAdapter)
 
     // run the code of the scene
-    await customEvalSdk7('exports.onUpdate = function() { return typeof setImmediate }', context)
+    await customEvalSdk7('exports.onUpdate = function() { return typeof setImmediate }', context, false)
 
     expect(await sceneModule.exports.onUpdate!(0)).toEqual('function')
   })
@@ -311,7 +311,7 @@ describe('dcl runtime', () => {
     const context = Object.create({ fn })
     const sceneModule = createModuleRuntime(context, null as any, devToolsAdapter)
 
-    await customEvalSdk7('setImmediate(fn)', context)
+    await customEvalSdk7('setImmediate(fn)', context, false)
 
     expect(fn).not.toHaveBeenCalled()
     await sceneModule.runStart!()
@@ -332,7 +332,7 @@ describe('dcl runtime', () => {
     const context = Object.create(null)
     const sceneModule = createModuleRuntime(context, null as any, devToolsAdapter)
 
-    await customEvalSdk7('exports.onStart = function() { if(setImmediate !== globalThis.setImmediate) throw new Error("they are different") }', context)
+    await customEvalSdk7('exports.onStart = function() { if(setImmediate !== globalThis.setImmediate) throw new Error("they are different") }', context, false)
     await sceneModule.exports.onStart!()
   })
 })


### PR DESCRIPTION
# What?
Make a plain `eval` to catch the source-maps properly in Preview Mode